### PR TITLE
Rename ADS nodes to ads-over-mqtt variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ ADS symbols using MQTT messages.
 
 ## Nodes
 
-- **ads-client-connection** – configuration node that establishes the MQTT
+- **ads-over-mqtt-client-connection** – configuration node that establishes the MQTT
   connection and holds AMS routing parameters.
-- **ads-client-read-symbol** – reads the value of a given ADS symbol. The symbol
+- **ads-over-mqtt-client-read-symbols** – reads the value of a given ADS symbol. The symbol
   can be configured in the node or supplied as `msg.symbol`.
-- **ads-client-write-symbol** – writes a value from `msg.payload` to the
+- **ads-over-mqtt-write-symbols** – writes a value from `msg.payload` to the
   specified ADS symbol.
 
 These nodes publish and subscribe to the following MQTT topics:

--- a/nodes/ads-over-mqtt-client-connection.html
+++ b/nodes/ads-over-mqtt-client-connection.html
@@ -1,5 +1,5 @@
 <script type="text/javascript">
-  RED.nodes.registerType('ads-client-connection', {
+  RED.nodes.registerType('ads-over-mqtt-client-connection', {
       category: 'config',
       defaults: {
           brokerUrl: {value:'mqtt://localhost:1883', required:true},
@@ -18,7 +18,7 @@
   });
 </script>
 
-<script type="text/x-red" data-template-name="ads-client-connection">
+<script type="text/x-red" data-template-name="ads-over-mqtt-client-connection">
   <div class="form-row">
     <label for="node-config-input-brokerUrl"><i class="fa fa-globe"></i> Broker URL</label>
     <input type="text" id="node-config-input-brokerUrl">
@@ -49,6 +49,6 @@
   </div>
 </script>
 
-<script type="text/x-red" data-help-name="ads-client-connection">
+<script type="text/x-red" data-help-name="ads-over-mqtt-client-connection">
   <p>Configuration for ADS over MQTT connection.</p>
 </script>

--- a/nodes/ads-over-mqtt-client-connection.js
+++ b/nodes/ads-over-mqtt-client-connection.js
@@ -1,8 +1,8 @@
-// nodes/ads-client-connection.js
+// nodes/ads-over-mqtt-client-connection.js
 module.exports = function (RED) {
   const mqtt = require("mqtt");
 
-  function AdsClientConnection(config) {
+  function AdsOverMqttClientConnection(config) {
     RED.nodes.createNode(this, config);
     const node = this;
 
@@ -19,7 +19,7 @@ module.exports = function (RED) {
 
     if (!node.brokerUrl) {
       node.status({ fill: "red", shape: "ring", text: "missing brokerUrl" });
-      node.error("ads-client-connection: brokerUrl fehlt");
+      node.error("ads-over-mqtt-client-connection: brokerUrl fehlt");
       return;
     }
 
@@ -87,7 +87,7 @@ module.exports = function (RED) {
     };
   }
 
-  RED.nodes.registerType("ads-client-connection", AdsClientConnection, {
+  RED.nodes.registerType("ads-over-mqtt-client-connection", AdsOverMqttClientConnection, {
     credentials: {
       username: { type: "text" },
       password: { type: "password" },

--- a/nodes/ads-over-mqtt-client-read-symbols.html
+++ b/nodes/ads-over-mqtt-client-read-symbols.html
@@ -1,10 +1,10 @@
 <script type="text/javascript">
-  RED.nodes.registerType('ads-client-read-symbol', {
+  RED.nodes.registerType('ads-over-mqtt-client-read-symbols', {
     category: 'function',
     color: '#a6bbcf',
     defaults: {
       name: {value:""},
-      connection: {type:"ads-client-connection", required:true},
+      connection: {type:"ads-over-mqtt-client-connection", required:true},
       symbol: {value:"", required:true}
     },
     inputs: 1,
@@ -16,7 +16,7 @@
   });
 </script>
 
-<script type="text/x-red" data-template-name="ads-client-read-symbol">
+<script type="text/x-red" data-template-name="ads-over-mqtt-client-read-symbols">
   <div class="form-row">
     <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
     <input type="text" id="node-input-name">
@@ -31,7 +31,7 @@
   </div>
 </script>
 
-<script type="text/x-red" data-help-name="ads-client-read-symbol">
+<script type="text/x-red" data-help-name="ads-over-mqtt-client-read-symbols">
   <p>Reads a symbol value from an ADS device over MQTT.</p>
   <p><b>Inputs</b>: <code>msg.symbol</code> can override the configured symbol.</p>
   <p><b>Outputs</b>: <code>msg.payload</code> contains the value of the symbol.</p>

--- a/nodes/ads-over-mqtt-client-read-symbols.js
+++ b/nodes/ads-over-mqtt-client-read-symbols.js
@@ -1,5 +1,5 @@
 module.exports = function(RED) {
-  function AdsClientReadSymbol(config) {
+  function AdsOverMqttClientReadSymbols(config) {
     RED.nodes.createNode(this, config);
     const node = this;
     node.symbol = config.symbol;
@@ -39,5 +39,5 @@ module.exports = function(RED) {
       done();
     });
   }
-  RED.nodes.registerType('ads-client-read-symbol', AdsClientReadSymbol);
+  RED.nodes.registerType('ads-over-mqtt-client-read-symbols', AdsOverMqttClientReadSymbols);
 };

--- a/nodes/ads-over-mqtt-write-symbols.html
+++ b/nodes/ads-over-mqtt-write-symbols.html
@@ -1,10 +1,10 @@
 <script type="text/javascript">
-  RED.nodes.registerType('ads-client-write-symbol', {
+  RED.nodes.registerType('ads-over-mqtt-write-symbols', {
     category: 'function',
     color: '#c6dbef',
     defaults: {
       name: {value:""},
-      connection: {type:"ads-client-connection", required:true},
+      connection: {type:"ads-over-mqtt-client-connection", required:true},
       symbol: {value:"", required:true}
     },
     inputs: 1,
@@ -16,7 +16,7 @@
   });
 </script>
 
-<script type="text/x-red" data-template-name="ads-client-write-symbol">
+<script type="text/x-red" data-template-name="ads-over-mqtt-write-symbols">
   <div class="form-row">
     <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
     <input type="text" id="node-input-name">
@@ -31,7 +31,7 @@
   </div>
 </script>
 
-<script type="text/x-red" data-help-name="ads-client-write-symbol">
+<script type="text/x-red" data-help-name="ads-over-mqtt-write-symbols">
   <p>Writes a value to an ADS symbol over MQTT. The value is taken from <code>msg.payload</code>.</p>
   <p><b>Inputs</b>: <code>msg.symbol</code> can override the configured symbol.</p>
   <p><b>Outputs</b>: forwards the input message once published.</p>

--- a/nodes/ads-over-mqtt-write-symbols.js
+++ b/nodes/ads-over-mqtt-write-symbols.js
@@ -1,5 +1,5 @@
 module.exports = function(RED) {
-  function AdsClientWriteSymbol(config) {
+  function AdsOverMqttWriteSymbols(config) {
     RED.nodes.createNode(this, config);
     const node = this;
     node.symbol = config.symbol;
@@ -29,5 +29,5 @@ module.exports = function(RED) {
       done();
     });
   }
-  RED.nodes.registerType('ads-client-write-symbol', AdsClientWriteSymbol);
+  RED.nodes.registerType('ads-over-mqtt-write-symbols', AdsOverMqttWriteSymbols);
 };

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "keywords": ["node-red", "ads", "mqtt", "twincat"],
   "node-red": {
     "nodes": {
-      "ads-client-connection": "nodes/ads-client-connection.js",
-      "ads-client-read-symbol": "nodes/ads-client-read-symbol.js",
-      "ads-client-write-symbol": "nodes/ads-client-write-symbol.js"
+      "ads-over-mqtt-client-connection": "nodes/ads-over-mqtt-client-connection.js",
+      "ads-over-mqtt-client-read-symbols": "nodes/ads-over-mqtt-client-read-symbols.js",
+      "ads-over-mqtt-write-symbols": "nodes/ads-over-mqtt-write-symbols.js"
     }
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- rename node types to ads-over-mqtt-* names
- update documentation and Node-RED mappings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b69d4cd0508324a86c60728dea1b61