### PR TITLE
Add source port and namespaced ADS topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,15 @@ ADS symbols using MQTT messages.
 ## Nodes
 
 - **ads-over-mqtt-client-connection** – configuration node that establishes the MQTT
-  connection and holds AMS routing parameters.
+  connection and holds AMS routing parameters (including source port and namespace).
 - **ads-over-mqtt-client-read-symbols** – reads the value of a given ADS symbol. The symbol
   can be configured in the node or supplied as `msg.symbol`.
 - **ads-over-mqtt-write-symbols** – writes a value from `msg.payload` to the
   specified ADS symbol.
 
-These nodes publish requests to `VirtualAmsNetwork1/<targetAmsNetId>/ams` and
-listen for responses on `VirtualAmsNetwork1/<targetAmsNetId>/ams/res`. Messages
-on the old `<clientId>/<targetAmsNetId>/ams` topics are still accepted but will
-produce a warning.
+These nodes publish requests to `<namespace>/<targetAmsNetId>/ams` and listen
+for responses on `<namespace>/<sourceAmsNetId>/ams/res`. The `<namespace>` is
+the MQTT client ID configured in the connection node.
 
 Payloads are raw ADS/AMS frames. Within Node-RED flows they are represented as
 Buffers. When serialising to JSON (for example for MQTT nodes), the Buffer can

--- a/nodes/ads-over-mqtt-client-connection.html
+++ b/nodes/ads-over-mqtt-client-connection.html
@@ -6,6 +6,7 @@
           amsNetId: {value:'', required:true},
           targetAmsNetId: {value:'', required:true},
           port: {value:851, required:true, validate:RED.validators.number()},
+          sourcePort: {value:32905, required:true, validate:RED.validators.number()},
           clientId: {value:''}
       },
       credentials: {
@@ -34,6 +35,10 @@
   <div class="form-row">
     <label for="node-config-input-port"><i class="fa fa-plug"></i> Port</label>
     <input type="text" id="node-config-input-port">
+  </div>
+  <div class="form-row">
+    <label for="node-config-input-sourcePort"><i class="fa fa-plug"></i> Source Port</label>
+    <input type="text" id="node-config-input-sourcePort">
   </div>
   <div class="form-row">
     <label for="node-config-input-clientId"><i class="fa fa-id-badge"></i> Client ID</label>

--- a/nodes/ads-over-mqtt-client-connection.js
+++ b/nodes/ads-over-mqtt-client-connection.js
@@ -10,7 +10,9 @@ module.exports = function (RED) {
     node.brokerUrl = (config.brokerUrl || "").trim();
     node.amsNetId = (config.amsNetId || "").trim();
     node.targetAmsNetId = (config.targetAmsNetId || "").trim();
-    node.port = Number(config.port) || 851;
+    node.port = Number(config.port) || 851; // target port (remote ADS)
+    // Optional source port for this client (constant per session)
+    node.sourcePort = Number(config.sourcePort) || 32905;
 
     const { username, password } = node.credentials || {};
     const rawClientId = (config.clientId || "").trim();
@@ -87,6 +89,7 @@ module.exports = function (RED) {
         amsNetId: node.amsNetId,
         targetAmsNetId: node.targetAmsNetId,
         port: node.port,
+        sourcePort: node.sourcePort,
         clientId: node.clientId,
         client: node.client,
       };


### PR DESCRIPTION
## Summary
- allow configuring an ADS source port on the connection node
- publish requests and listen for responses under `<namespace>/...` topics using the connection's client ID
- switch symbol access to VALBYNAME (0xF004) payloads for read and write nodes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6bfdf03788324b89e416c97c5f362