### PR TITLE
feat: log ADS frame on second output

### DIFF
--- a/nodes/ads-over-mqtt-client-read-symbols.html
+++ b/nodes/ads-over-mqtt-client-read-symbols.html
@@ -8,7 +8,7 @@
       symbol: {value:"", required:true}
     },
     inputs: 1,
-    outputs: 1,
+    outputs: 2,
     icon: "bridge.png",
     label: function() {
       return this.name || this.symbol || 'ads read';
@@ -34,5 +34,9 @@
 <script type="text/x-red" data-help-name="ads-over-mqtt-client-read-symbols">
   <p>Reads a symbol value from an ADS device over MQTT.</p>
   <p><b>Inputs</b>: <code>msg.symbol</code> can override the configured symbol.</p>
-  <p><b>Outputs</b>: <code>msg.payload</code> contains the value of the symbol.</p>
+  <p><b>Outputs</b>:</p>
+  <ol>
+    <li><code>msg.payload</code> contains the value of the symbol.</li>
+    <li><code>msg.payload</code> contains the request frame as hex string.</li>
+  </ol>
 </script>

--- a/nodes/ads-over-mqtt-client-read-symbols.js
+++ b/nodes/ads-over-mqtt-client-read-symbols.js
@@ -42,7 +42,8 @@ module.exports = function (RED) {
       const data = message.slice(46, 46 + len);
 
       delete node.pendingRequests[invokeId];
-      pending.send({ payload: data, symbol: pending.symbol, invokeId, result });
+      const out = { payload: data, symbol: pending.symbol, invokeId, result };
+      pending.send([out, null]);
       pending.done();
     });
 
@@ -80,6 +81,10 @@ module.exports = function (RED) {
       tcpHeader.writeUInt32LE(amsHeader.length + adsRw.length, 2);
 
       const frame = Buffer.concat([tcpHeader, amsHeader, adsRw]);
+
+      const frameHex = frame.toString("hex");
+      node.debug(`Frame: ${frameHex}`);
+      send([null, { payload: frameHex }]);
 
       node.pendingRequests[invokeId] = { symbol, send, done };
       node.connection.client.publish(reqTopic, frame);

--- a/nodes/ads-over-mqtt-write-symbols.html
+++ b/nodes/ads-over-mqtt-write-symbols.html
@@ -8,7 +8,7 @@
       symbol: {value:"", required:true}
     },
     inputs: 1,
-    outputs: 1,
+    outputs: 2,
     icon: "bridge.png",
     label: function() {
       return this.name || this.symbol || 'ads write';
@@ -34,5 +34,9 @@
 <script type="text/x-red" data-help-name="ads-over-mqtt-write-symbols">
   <p>Writes a value to an ADS symbol over MQTT. The value is taken from <code>msg.payload</code>.</p>
   <p><b>Inputs</b>: <code>msg.symbol</code> can override the configured symbol.</p>
-  <p><b>Outputs</b>: forwards the input message once published.</p>
+  <p><b>Outputs</b>:</p>
+  <ol>
+    <li>Forwards the input message once published.</li>
+    <li><code>msg.payload</code> contains the request frame as hex string.</li>
+  </ol>
 </script>

--- a/nodes/ads-over-mqtt-write-symbols.js
+++ b/nodes/ads-over-mqtt-write-symbols.js
@@ -59,7 +59,8 @@ module.exports = function (RED) {
       const data = message.slice(46, 46 + len);
 
       delete node.pendingRequests[invokeId];
-      pending.send({ payload: data, symbol: pending.symbol, invokeId, result });
+      const out = { payload: data, symbol: pending.symbol, invokeId, result };
+      pending.send([out, null]);
       pending.done();
     });
 
@@ -105,6 +106,10 @@ module.exports = function (RED) {
       tcpHeader.writeUInt32LE(amsHeader.length + adsRw.length, 2);
 
       const frame = Buffer.concat([tcpHeader, amsHeader, adsRw]);
+
+      const frameHex = frame.toString("hex");
+      node.debug(`Frame: ${frameHex}`);
+      send([null, { payload: frameHex }]);
 
       node.pendingRequests[invokeId] = { symbol, send, done };
       node.connection.client.publish(reqTopic, frame);


### PR DESCRIPTION
## Summary
- add second output to ADS read/write nodes
- emit request frame as hex string on second output

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6eeae0bc0832489276d9cc5addacd