### PR TITLE
Add datatype dropdown for read node

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ ADS symbols using MQTT messages.
   connection and holds AMS routing parameters (including source port and namespace).
 - **ads-over-mqtt-client-read-symbols** – reads the value of a given ADS symbol. The symbol
   can be configured in the node or supplied as `msg.symbol`.
+  The data type can be selected in the node or provided as `msg.dateityp`.
 - **ads-over-mqtt-write-symbols** – writes a value from `msg.payload` to the
   specified ADS symbol.
 
@@ -31,9 +32,11 @@ be expressed as an object
 ```js
 // Read 4 bytes from symbol 'MAIN.myVar'
 msg.symbol = 'MAIN.myVar';
-msg.readLength = 4;
+msg.dateityp = 'DINT';
 return msg;
 ```
+
+For strings, `msg.stringLength` can override the configured length (default 80).
 
 If you need to inject a frame manually:
 
@@ -63,9 +66,12 @@ An example response for the above request:
 }
 ```
 
-The read node outputs the response data in `msg.payload` as a Buffer. The write
-node forwards an empty Buffer on success. Both nodes include the `invokeId` and
-ADS result code in the message.
+The read node outputs the response data in `msg.payload` as a Buffer. Both read
+and write nodes emit the hex representation of the request frame on their second
+output and the raw request frame Buffer on their third output; both debug
+outputs also include the MQTT topic in `msg.topic`. The write node forwards an
+empty Buffer on success. Both nodes include the `invokeId` and ADS result code
+in the message.
 
 ## Development
 

--- a/nodes/ads-over-mqtt-client-read-symbols.html
+++ b/nodes/ads-over-mqtt-client-read-symbols.html
@@ -5,14 +5,28 @@
     defaults: {
       name: {value:""},
       connection: {type:"ads-over-mqtt-client-connection", required:true},
-      symbol: {value:"", required:true}
+      symbol: {value:"", required:true},
+      dateityp: {value:"DINT"},
+      stringLength: {value:80}
     },
     inputs: 1,
-    outputs: 2,
-    outputLabels: ["ADS Response", "Debug"],
+    outputs: 3,
+    outputLabels: ["ADS Response", "Debug Hex", "Debug Binary"],
     icon: "bridge.png",
     label: function() {
       return this.name || this.symbol || 'ads read';
+    },
+    oneditprepare: function() {
+      var $dt = $("#node-input-dateityp");
+      function updateStringLength() {
+        if ($dt.val() === "STRING") {
+          $(".node-input-stringLength-row").show();
+        } else {
+          $(".node-input-stringLength-row").hide();
+        }
+      }
+      $dt.on("change", updateStringLength);
+      updateStringLength();
     }
   });
 </script>
@@ -30,14 +44,51 @@
     <label for="node-input-symbol"><i class="fa fa-book"></i> Symbol</label>
     <input type="text" id="node-input-symbol">
   </div>
+  <div class="form-row">
+    <label for="node-input-dateityp"><i class="fa fa-list"></i> Dateityp</label>
+    <select id="node-input-dateityp">
+      <optgroup label="1 Byte">
+        <option value="BOOL">BOOL</option>
+        <option value="BYTE">BYTE</option>
+        <option value="SINT">SINT</option>
+        <option value="USINT">USINT</option>
+      </optgroup>
+      <optgroup label="2 Byte">
+        <option value="INT">INT</option>
+        <option value="UINT">UINT</option>
+        <option value="WORD">WORD</option>
+      </optgroup>
+      <optgroup label="4 Byte">
+        <option value="DINT">DINT</option>
+        <option value="UDINT">UDINT</option>
+        <option value="DWORD">DWORD</option>
+        <option value="REAL">REAL</option>
+      </optgroup>
+      <optgroup label="8 Byte">
+        <option value="LINT">LINT</option>
+        <option value="ULINT">ULINT</option>
+        <option value="LREAL">LREAL</option>
+      </optgroup>
+      <optgroup label="STRING">
+        <option value="STRING">STRING</option>
+      </optgroup>
+    </select>
+  </div>
+  <div class="form-row node-input-stringLength-row">
+    <label for="node-input-stringLength"><i class="fa fa-text-width"></i> STRING Länge</label>
+    <input type="number" id="node-input-stringLength" min="1">
+  </div>
 </script>
 
 <script type="text/x-red" data-help-name="ads-over-mqtt-client-read-symbols">
   <p>Reads a symbol value from an ADS device over MQTT.</p>
-  <p><b>Inputs</b>: <code>msg.symbol</code> can override the configured symbol.</p>
+  <p><b>Inputs</b>: <code>msg.symbol</code> can override the configured symbol.
+  <code>msg.dateityp</code> can override the data type.
+  <code>msg.stringLength</code> sets the length for strings.</p>
   <p><b>Outputs</b>:</p>
   <ol>
     <li><code>msg.payload</code> contains the value of the symbol.</li>
     <li><code>msg.payload</code> contains the hex string of the ADS request frame and <code>msg.topic</code> the MQTT topic.</li>
+    <li><code>msg.payload</code> contains the raw ADS request frame as a Buffer and <code>msg.topic</code> the MQTT topic.</li>
   </ol>
 </script>

--- a/nodes/ads-over-mqtt-client-read-symbols.js
+++ b/nodes/ads-over-mqtt-client-read-symbols.js
@@ -3,6 +3,8 @@ module.exports = function (RED) {
     RED.nodes.createNode(this, config);
     const node = this;
     node.symbol = config.symbol;
+    node.dateityp = config.dateityp;
+    node.stringLength = Number(config.stringLength) || 80;
     node.connection = RED.nodes.getNode(config.connection);
 
     if (!node.connection || !node.connection.client) {
@@ -46,13 +48,49 @@ module.exports = function (RED) {
       pending.send([
         { payload: data, symbol: pending.symbol, invokeId, result },
         null,
+        null,
       ]);
       pending.done();
     });
 
     node.on("input", (msg, send, done) => {
       const symbol = msg.symbol || node.symbol;
-      const readLength = Number(msg.readLength) || 0;
+      const dateityp = msg.dateityp || node.dateityp;
+      let readLength = 0;
+      if (dateityp) {
+        switch (dateityp) {
+          case "BOOL":
+          case "BYTE":
+          case "SINT":
+          case "USINT":
+            readLength = 1;
+            break;
+          case "INT":
+          case "UINT":
+          case "WORD":
+            readLength = 2;
+            break;
+          case "DINT":
+          case "UDINT":
+          case "DWORD":
+          case "REAL":
+            readLength = 4;
+            break;
+          case "LINT":
+          case "ULINT":
+          case "LREAL":
+            readLength = 8;
+            break;
+          case "STRING":
+            readLength = Number(msg.stringLength || node.stringLength || 80);
+            msg.encoding = "ascii";
+            break;
+          default:
+            readLength = 0;
+        }
+      } else {
+        readLength = Number(msg.readLength) || 0;
+      }
       if (!symbol) {
         done(new Error("No symbol specified"));
         return;
@@ -88,11 +126,15 @@ module.exports = function (RED) {
       const hex = frame.toString('hex');
       node.debug(`Frame: ${hex}`);
 
-      // emit debug information on second output
+      // emit debug information on second and third outputs
       send([
         null,
         {
           payload: hex,
+          topic: reqTopic,
+        },
+        {
+          payload: frame,
           topic: reqTopic,
         },
       ]);

--- a/nodes/ads-over-mqtt-write-symbols.html
+++ b/nodes/ads-over-mqtt-write-symbols.html
@@ -8,7 +8,8 @@
       symbol: {value:"", required:true}
     },
     inputs: 1,
-    outputs: 1,
+    outputs: 3,
+    outputLabels: ["ADS Response", "Debug Hex", "Debug Binary"],
     icon: "bridge.png",
     label: function() {
       return this.name || this.symbol || 'ads write';
@@ -34,5 +35,10 @@
 <script type="text/x-red" data-help-name="ads-over-mqtt-write-symbols">
   <p>Writes a value to an ADS symbol over MQTT. The value is taken from <code>msg.payload</code>.</p>
   <p><b>Inputs</b>: <code>msg.symbol</code> can override the configured symbol.</p>
-  <p><b>Outputs</b>: forwards the input message once published.</p>
+  <p><b>Outputs</b>:</p>
+  <ol>
+    <li><code>msg.payload</code> contains the ADS response (usually an empty Buffer) once acknowledged.</li>
+    <li><code>msg.payload</code> contains the hex string of the ADS request frame and <code>msg.topic</code> the MQTT topic.</li>
+    <li><code>msg.payload</code> contains the raw ADS request frame as a Buffer and <code>msg.topic</code> the MQTT topic.</li>
+  </ol>
 </script>

--- a/nodes/ads-over-mqtt-write-symbols.js
+++ b/nodes/ads-over-mqtt-write-symbols.js
@@ -59,7 +59,11 @@ module.exports = function (RED) {
       const data = message.slice(46, 46 + len);
 
       delete node.pendingRequests[invokeId];
-      pending.send({ payload: data, symbol: pending.symbol, invokeId, result });
+      pending.send([
+        { payload: data, symbol: pending.symbol, invokeId, result },
+        null,
+        null,
+      ]);
       pending.done();
     });
 
@@ -106,7 +110,21 @@ module.exports = function (RED) {
 
       const frame = Buffer.concat([tcpHeader, amsHeader, adsRw]);
 
-      node.debug(`Frame: ${frame.toString('hex')}`);
+      const hex = frame.toString('hex');
+      node.debug(`Frame: ${hex}`);
+
+      // emit debug information on second and third outputs
+      send([
+        null,
+        {
+          payload: hex,
+          topic: reqTopic,
+        },
+        {
+          payload: frame,
+          topic: reqTopic,
+        },
+      ]);
 
       node.pendingRequests[invokeId] = { symbol, send, done };
       node.connection.client.publish(reqTopic, frame);


### PR DESCRIPTION
## Summary
- add Dateityp dropdown for read symbols node with grouped options and optional STRING length
- determine read length and string encoding from selected or incoming `msg.dateityp`
- emit raw request frame on new third debug output for read and write nodes
- document new `msg.dateityp`, `msg.stringLength` and binary debug output

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7da0e4d108324865d30f0ed387cac