### PR TITLE
feat: add trigger-based symbol loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ ADS symbols using MQTT messages.
   use the value from the connection node. It also defines the internal
   MQTT topic prefix used for ADS messages.
 - **ads-over-mqtt-symbol-loader** – loads the complete symbol table from a
-  target and caches it in `global.symbols`.
+  target and caches it in `global.symbols`. It triggers on input and reports the
+  status every 5 seconds on its first output. The second and third outputs
+  provide hex and raw debug frames of the ADS requests.
 - **ads-over-mqtt-client-read-symbols** – reads the value of a given ADS symbol
   using the cached symbol information. The symbol can be configured in the node
   or supplied as `msg.symbol`.

--- a/nodes/ads-over-mqtt-symbol-loader.html
+++ b/nodes/ads-over-mqtt-symbol-loader.html
@@ -6,9 +6,9 @@
       name: {value:""},
       connection: {type:"ads-over-mqtt-client-connection", required:true}
     },
-    inputs: 0,
-    outputs: 1,
-    outputLabels: ["Status"],
+    inputs: 1,
+    outputs: 3,
+    outputLabels: ["Status", "Debug Hex", "Debug Raw"],
     icon: "bridge.png",
     label: function() {
       return this.name || 'ads symbol loader';
@@ -28,6 +28,7 @@
 </script>
 
 <script type="text/x-red" data-help-name="ads-over-mqtt-symbol-loader">
-  <p>Loads the complete ADS symbol table from the selected SPS via ADS over MQTT and caches it in <code>global.symbols</code>.</p>
-  <p>The node outputs the status every 5 seconds.</p>
+  <p>On trigger input, loads the complete ADS symbol table from the selected SPS via ADS over MQTT and caches it in <code>global.symbols</code>.</p>
+  <p>Output 1 reports status every 5 seconds.</p>
+  <p>Outputs 2 and 3 contain the hex string and raw Buffer of each published ADS request for debugging.</p>
 </script>


### PR DESCRIPTION
## Summary
- load symbols on input trigger instead of on start
- provide status and debug outputs for ADS requests
- document symbol loader behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b805fa15148324a2da717dbd46bc80