### PR TITLE
Add ADS over MQTT debug node

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ ADS symbols using MQTT messages.
   or supplied as `msg.symbol`.
 - **ads-over-mqtt-write-symbols** – writes a value from `msg.payload` to the
   specified ADS symbol using the cached symbol information.
+- **ads-over-mqtt-debug** – subscribes to a topic via the configured connection
+  and outputs incoming messages as Buffers.
 
 These nodes publish requests to `<topic>/<targetAmsNetId>/ams` and listen
 for responses on `<topic>/<sourceAmsNetId>/ams/res`. The `<targetAmsNetId>`

--- a/nodes/ads-over-mqtt-debug.html
+++ b/nodes/ads-over-mqtt-debug.html
@@ -1,0 +1,36 @@
+<script type="text/javascript">
+  RED.nodes.registerType('ads-over-mqtt-debug', {
+    category: 'function',
+    color: '#b6e7a1',
+    defaults: {
+      name: {value:""},
+      connection: {type:"ads-over-mqtt-client-connection", required:true},
+      pfad: {value:"", required:true}
+    },
+    inputs: 0,
+    outputs: 1,
+    icon: 'bridge.png',
+    label: function() {
+      return this.name || this.pfad || 'ads debug';
+    }
+  });
+</script>
+
+<script type="text/x-red" data-template-name="ads-over-mqtt-debug">
+  <div class="form-row">
+    <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+    <input type="text" id="node-input-name">
+  </div>
+  <div class="form-row">
+    <label for="node-input-connection"><i class="fa fa-plug"></i> Connection</label>
+    <input type="text" id="node-input-connection">
+  </div>
+  <div class="form-row">
+    <label for="node-input-pfad"><i class="fa fa-rss"></i> Pfad</label>
+    <input type="text" id="node-input-pfad">
+  </div>
+</script>
+
+  <script type="text/x-red" data-help-name="ads-over-mqtt-debug">
+    <p>Subscribes to a topic via the configured ADS over MQTT connection and outputs received messages as binary Buffers.</p>
+  </script>

--- a/nodes/ads-over-mqtt-debug.js
+++ b/nodes/ads-over-mqtt-debug.js
@@ -1,0 +1,46 @@
+module.exports = function (RED) {
+  function AdsOverMqttDebug(config) {
+    RED.nodes.createNode(this, config);
+    const node = this;
+    node.pfad = config.pfad;
+    node.connection = RED.nodes.getNode(config.connection);
+
+    if (!node.connection || !node.connection.client) {
+      node.error("No ADS connection configured");
+      return;
+    }
+
+    if (!node.pfad) {
+      node.status({ fill: "red", shape: "ring", text: "missing topic" });
+      node.error("ads-over-mqtt-debug: pfad is empty");
+      return;
+    }
+
+    node.status({ fill: "yellow", shape: "ring", text: "subscribing…" });
+
+    node._onMessage = (topic, message) => {
+      if (topic === node.pfad) {
+        node.send({ payload: message, topic });
+      }
+    };
+
+    node.connection.client.on("message", node._onMessage);
+    node.connection.client.subscribe(node.pfad, (err) => {
+      if (err) {
+        node.status({ fill: "red", shape: "dot", text: "subscribe error" });
+        node.error(err);
+      } else {
+        node.status({ fill: "green", shape: "dot", text: "listening" });
+      }
+    });
+
+    node.on("close", (done) => {
+      if (node._onMessage) {
+        node.connection.client.off("message", node._onMessage);
+      }
+      node.connection.client.unsubscribe(node.pfad, done);
+    });
+  }
+
+  RED.nodes.registerType("ads-over-mqtt-debug", AdsOverMqttDebug);
+};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
       "ads-over-mqtt-client-connection": "nodes/ads-over-mqtt-client-connection.js",
       "ads-over-mqtt-client-read-symbols": "nodes/ads-over-mqtt-client-read-symbols.js",
       "ads-over-mqtt-write-symbols": "nodes/ads-over-mqtt-write-symbols.js",
-      "ads-over-mqtt-symbol-loader": "nodes/ads-over-mqtt-symbol-loader.js"
+      "ads-over-mqtt-symbol-loader": "nodes/ads-over-mqtt-symbol-loader.js",
+      "ads-over-mqtt-debug": "nodes/ads-over-mqtt-debug.js"
     }
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add ads-over-mqtt-debug node to subscribe to arbitrary ADS MQTT topics and output raw payloads
- document new debug node in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8304aa8bc8324b84d299912a0527e