### PR TITLE
feat: add automatic symbol upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ ADS symbols using MQTT messages.
   This is the only place where the Target AMS Net ID is set. All other nodes
   use the value from the connection node. It also defines the internal
   MQTT topic prefix used for ADS messages.
-- **ads-over-mqtt-symbol-loader** – loads the complete symbol table from a
-  target and caches it in `global.symbols`. It triggers on input and reports the
-  status every 5 seconds on its first output. The second and third outputs
-  provide hex and raw debug frames of the ADS requests.
+- **ads-over-mqtt-symbol-loader** – on trigger, requests the symbol upload
+  information and complete symbol table from a target. The parsed symbol list is
+  sent on the first output and includes `msg.count` and `msg.size`. The list is
+  cached in `flow.symbols` (namespaced by topic and target) and `global.symbols`.
+  Outputs two and three provide hex and raw debug frames of the ADS requests.
 - **ads-over-mqtt-client-read-symbols** – reads the value of a given ADS symbol
   using the cached symbol information. The symbol can be configured in the node
   or supplied as `msg.symbol`.

--- a/nodes/ads-over-mqtt-symbol-loader.html
+++ b/nodes/ads-over-mqtt-symbol-loader.html
@@ -8,7 +8,7 @@
     },
     inputs: 1,
     outputs: 3,
-    outputLabels: ["Status", "Debug Hex", "Debug Raw"],
+    outputLabels: ["Symbols", "Debug Hex", "Debug Raw"],
     icon: "bridge.png",
     label: function() {
       return this.name || 'ads symbol loader';
@@ -28,7 +28,7 @@
 </script>
 
 <script type="text/x-red" data-help-name="ads-over-mqtt-symbol-loader">
-  <p>On trigger input, loads the complete ADS symbol table from the selected SPS via ADS over MQTT and caches it in <code>global.symbols</code>.</p>
-  <p>Output 1 reports status every 5 seconds.</p>
+  <p>On trigger input, queries the symbol upload information and complete ADS symbol table from the selected target via ADS over MQTT and outputs the parsed symbol list on <code>msg.payload</code>.</p>
+  <p><code>msg.count</code> contains the number of symbols and <code>msg.size</code> the total size in bytes. The list is also cached in <code>flow.symbols</code> (namespaced by topic and target) and in <code>global.symbols</code> for compatibility.</p>
   <p>Outputs 2 and 3 contain the hex string and raw Buffer of each published ADS request for debugging.</p>
 </script>


### PR DESCRIPTION
## Summary
- load ADS symbol table in two steps and parse entries with type information
- expose symbol list with count and size, storing cache in flow and global scope
- document symbol loader output and behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b96f461ad483248e316de99df8fdbe