### PR TITLE
Fix off-by-one in ADS symbol type parsing

### DIFF
--- a/nodes/ads-over-mqtt-symbol-loader.js
+++ b/nodes/ads-over-mqtt-symbol-loader.js
@@ -107,9 +107,25 @@ module.exports = function (RED) {
           .toString("utf8")
           .replace(/\0+$/, "");
 
-        const typeStart = nameStart + nameLength;
+        let typeStart = nameStart + nameLength;
+        let typeLen = typeLength;
+        if (typeLen > 0 && buffer[typeStart] === 0x00) {
+          typeStart += 1;
+          typeLen -= 1;
+        }
         const typeName = buffer
-          .slice(typeStart, typeStart + typeLength)
+          .slice(typeStart, typeStart + typeLen)
+          .toString("utf8")
+          .replace(/\0+$/, "");
+
+        let commentStart = typeStart + typeLen;
+        let commentLen = commentLength;
+        if (commentLen > 0 && buffer[commentStart] === 0x00) {
+          commentStart += 1;
+          commentLen -= 1;
+        }
+        const comment = buffer
+          .slice(commentStart, commentStart + commentLen)
           .toString("utf8")
           .replace(/\0+$/, "");
 
@@ -120,6 +136,7 @@ module.exports = function (RED) {
           indexOffset,
           size,
           typeName,
+          comment,
           dataType,
           flags,
         });


### PR DESCRIPTION
## Summary
- Adjust ADS symbol parser to skip optional null separators before type and comment strings
- Capture comments while parsing symbols

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b985f0730883249b49892f9f35e82f