### PR TITLE
feat: add manual value option for ADS MQTT nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,13 @@ ADS symbols using MQTT messages.
   Outputs two and three provide hex and raw debug frames of the ADS requests.
 - **ads-over-mqtt-client-read-symbols** – reads the value of a given ADS symbol
   using the cached symbol information. The symbol can be configured in the node
-  or supplied as `msg.symbol`.
+  or supplied as `msg.symbol`. Activating the *Manuelle Werte verwenden* option
+  reveals fields for Index Group, Index Offset, Size and Type which, when set,
+  are used instead of the cached symbol data.
 - **ads-over-mqtt-write-symbols** – writes a value from `msg.payload` to the
-  specified ADS symbol using the cached symbol information.
+  specified ADS symbol using the cached symbol information. Enabling *Manuelle
+  Werte verwenden* allows manual entry of Index Group, Index Offset, Size and
+  Type which take precedence over cached values.
 - **ads-over-mqtt-info** – publishes a static info message to
   `<topic>/<localAmsNetId>/info` when triggered via its button.
 

--- a/nodes/ads-over-mqtt-client-read-symbols.html
+++ b/nodes/ads-over-mqtt-client-read-symbols.html
@@ -8,18 +8,37 @@
       symbol: {
         value:"",
         validate: function(v) {
-          return v || (
-            $("#node-input-ig").val() !== "" &&
-            $("#node-input-io").val() !== "" &&
-            $("#node-input-size").val() !== "" &&
-            $("#node-input-typeName").val() !== ""
-          );
+          if ($("#node-input-manual").is(":checked")) {
+            return true;
+          }
+          return v !== "";
         }
       },
-      ig: {value:""},
-      io: {value:""},
-      size: {value:""},
-      typeName: {value:""}
+      manual: {value:false},
+      ig: {
+        value:"",
+        validate: function(v) {
+          return !$("#node-input-manual").is(":checked") || v !== "";
+        }
+      },
+      io: {
+        value:"",
+        validate: function(v) {
+          return !$("#node-input-manual").is(":checked") || v !== "";
+        }
+      },
+      size: {
+        value:"",
+        validate: function(v) {
+          return !$("#node-input-manual").is(":checked") || v !== "";
+        }
+      },
+      typeName: {
+        value:"",
+        validate: function(v) {
+          return !$("#node-input-manual").is(":checked") || v !== "";
+        }
+      }
     },
     inputs: 1,
     outputs: 3,
@@ -27,6 +46,14 @@
     icon: "bridge.png",
     label: function() {
       return this.name || this.symbol || 'ads read';
+    },
+    oneditprepare: function() {
+      function toggleManual() {
+        var show = $("#node-input-manual").is(":checked");
+        $(".ads-manual").toggle(show);
+      }
+      $("#node-input-manual").on("change", toggleManual);
+      toggleManual();
     }
   });
 </script>
@@ -45,18 +72,23 @@
     <input type="text" id="node-input-symbol">
   </div>
   <div class="form-row">
+    <label>&nbsp;</label>
+    <input type="checkbox" id="node-input-manual" style="width:auto; margin-left:0;">
+    <label for="node-input-manual" style="width:auto;">Manuelle Werte verwenden</label>
+  </div>
+  <div class="form-row ads-manual">
     <label for="node-input-ig"><i class="fa fa-list-ol"></i> Index Group</label>
     <input type="number" id="node-input-ig">
   </div>
-  <div class="form-row">
+  <div class="form-row ads-manual">
     <label for="node-input-io"><i class="fa fa-list-ol"></i> Index Offset</label>
     <input type="number" id="node-input-io">
   </div>
-  <div class="form-row">
+  <div class="form-row ads-manual">
     <label for="node-input-size"><i class="fa fa-arrows-h"></i> Size</label>
     <input type="number" id="node-input-size">
   </div>
-  <div class="form-row">
+  <div class="form-row ads-manual">
     <label for="node-input-typeName"><i class="fa fa-list"></i> Type</label>
     <select id="node-input-typeName">
       <option value=""></option>
@@ -71,8 +103,8 @@
 </script>
 
 <script type="text/x-red" data-help-name="ads-over-mqtt-client-read-symbols">
-  <p>Reads a value from an ADS device over MQTT. You may manually specify the Index Group, Index Offset, Size and Type; when provided, these override any values from the cached symbol information.</p>
-  <p>A symbol is only required if any of the manual fields are left blank. <code>msg.symbol</code> can override the configured symbol.</p>
+  <p>Reads a value from an ADS device over MQTT. Enable <i>Manuelle Werte verwenden</i> to manually specify the Index Group, Index Offset, Size and Type. When disabled, these values are taken from the cached symbol information.</p>
+  <p>A symbol is required when manual values are not used. <code>msg.symbol</code> can override the configured symbol.</p>
   <p><b>Outputs</b>:</p>
   <ol>
     <li><code>msg.payload</code> contains the decoded value of the symbol.</li>

--- a/nodes/ads-over-mqtt-client-read-symbols.js
+++ b/nodes/ads-over-mqtt-client-read-symbols.js
@@ -3,6 +3,7 @@ module.exports = function (RED) {
     RED.nodes.createNode(this, config);
     const node = this;
     node.symbol = config.symbol;
+    node.manual = config.manual;
     node.ig =
       config.ig !== undefined && config.ig !== "" ? parseInt(config.ig, 10) : undefined;
     node.io =
@@ -87,12 +88,17 @@ module.exports = function (RED) {
         return;
       }
 
-      let ig = node.ig;
-      let io = node.io;
-      let size = node.size;
-      let typeName = node.typeName;
-
-      if (ig === undefined || io === undefined || size === undefined || !typeName) {
+      let ig, io, size, typeName;
+      if (node.manual) {
+        ig = node.ig;
+        io = node.io;
+        size = node.size;
+        typeName = node.typeName;
+        if (ig === undefined || io === undefined || size === undefined || !typeName) {
+          done(new Error("Index Group, Offset, Size or Type missing"));
+          return;
+        }
+      } else {
         if (!symbol) {
           done(new Error("No symbol specified"));
           return;
@@ -106,15 +112,10 @@ module.exports = function (RED) {
           done(new Error("Symbol not found in cache"));
           return;
         }
-        if (ig === undefined) ig = symInfo.indexGroup;
-        if (io === undefined) io = symInfo.indexOffset;
-        if (size === undefined) size = symInfo.size;
-        if (!typeName) typeName = symInfo.typeName;
-      }
-
-      if (ig === undefined || io === undefined || size === undefined || !typeName) {
-        done(new Error("Index Group, Offset, Size or Type missing"));
-        return;
+        ig = symInfo.indexGroup;
+        io = symInfo.indexOffset;
+        size = symInfo.size;
+        typeName = symInfo.typeName;
       }
 
       const reqTopic = `${namespace}/${targetAms}/ams`;

--- a/nodes/ads-over-mqtt-write-symbols.html
+++ b/nodes/ads-over-mqtt-write-symbols.html
@@ -8,18 +8,37 @@
       symbol: {
         value:"",
         validate: function(v) {
-          return v || (
-            $("#node-input-ig").val() !== "" &&
-            $("#node-input-io").val() !== "" &&
-            $("#node-input-size").val() !== "" &&
-            $("#node-input-typeName").val() !== ""
-          );
+          if ($("#node-input-manual").is(":checked")) {
+            return true;
+          }
+          return v !== "";
         }
       },
-      ig: {value:""},
-      io: {value:""},
-      size: {value:""},
-      typeName: {value:""}
+      manual: {value:false},
+      ig: {
+        value:"",
+        validate: function(v) {
+          return !$("#node-input-manual").is(":checked") || v !== "";
+        }
+      },
+      io: {
+        value:"",
+        validate: function(v) {
+          return !$("#node-input-manual").is(":checked") || v !== "";
+        }
+      },
+      size: {
+        value:"",
+        validate: function(v) {
+          return !$("#node-input-manual").is(":checked") || v !== "";
+        }
+      },
+      typeName: {
+        value:"",
+        validate: function(v) {
+          return !$("#node-input-manual").is(":checked") || v !== "";
+        }
+      }
     },
     inputs: 1,
     outputs: 3,
@@ -27,6 +46,14 @@
     icon: "bridge.png",
     label: function() {
       return this.name || this.symbol || 'ads write';
+    },
+    oneditprepare: function() {
+      function toggleManual() {
+        var show = $("#node-input-manual").is(":checked");
+        $(".ads-manual").toggle(show);
+      }
+      $("#node-input-manual").on("change", toggleManual);
+      toggleManual();
     }
   });
 </script>
@@ -45,18 +72,23 @@
     <input type="text" id="node-input-symbol">
   </div>
   <div class="form-row">
+    <label>&nbsp;</label>
+    <input type="checkbox" id="node-input-manual" style="width:auto; margin-left:0;">
+    <label for="node-input-manual" style="width:auto;">Manuelle Werte verwenden</label>
+  </div>
+  <div class="form-row ads-manual">
     <label for="node-input-ig"><i class="fa fa-list-ol"></i> Index Group</label>
     <input type="number" id="node-input-ig">
   </div>
-  <div class="form-row">
+  <div class="form-row ads-manual">
     <label for="node-input-io"><i class="fa fa-list-ol"></i> Index Offset</label>
     <input type="number" id="node-input-io">
   </div>
-  <div class="form-row">
+  <div class="form-row ads-manual">
     <label for="node-input-size"><i class="fa fa-arrows-h"></i> Size</label>
     <input type="number" id="node-input-size">
   </div>
-  <div class="form-row">
+  <div class="form-row ads-manual">
     <label for="node-input-typeName"><i class="fa fa-list"></i> Type</label>
     <select id="node-input-typeName">
       <option value=""></option>
@@ -71,8 +103,8 @@
 </script>
 
 <script type="text/x-red" data-help-name="ads-over-mqtt-write-symbols">
-  <p>Writes a value to an ADS symbol over MQTT. The value is taken from <code>msg.payload</code>. Index Group, Index Offset, Size and Type may be set manually and take precedence over cached symbol information.</p>
-  <p>A symbol is only required if any of the manual fields are not provided. <code>msg.symbol</code> can override the configured symbol.</p>
+  <p>Writes a value to an ADS symbol over MQTT. The value is taken from <code>msg.payload</code>. Enable <i>Manuelle Werte verwenden</i> to manually specify the Index Group, Index Offset, Size and Type. When disabled, the node uses cached symbol information.</p>
+  <p>A symbol is required when manual values are not used. <code>msg.symbol</code> can override the configured symbol.</p>
   <p><b>Outputs</b>:</p>
   <ol>
     <li><code>msg.payload</code> contains the ADS response (usually an empty Buffer) once acknowledged.</li>

--- a/nodes/ads-over-mqtt-write-symbols.js
+++ b/nodes/ads-over-mqtt-write-symbols.js
@@ -3,6 +3,7 @@ module.exports = function (RED) {
     RED.nodes.createNode(this, config);
     const node = this;
     node.symbol = config.symbol;
+    node.manual = config.manual;
     node.ig =
       config.ig !== undefined && config.ig !== "" ? parseInt(config.ig, 10) : undefined;
     node.io =
@@ -145,12 +146,17 @@ module.exports = function (RED) {
         return;
       }
 
-      let ig = node.ig;
-      let io = node.io;
-      let size = node.size;
-      let typeName = node.typeName;
-
-      if (ig === undefined || io === undefined || size === undefined || !typeName) {
+      let ig, io, size, typeName;
+      if (node.manual) {
+        ig = node.ig;
+        io = node.io;
+        size = node.size;
+        typeName = node.typeName;
+        if (ig === undefined || io === undefined || size === undefined || !typeName) {
+          done(new Error("Index Group, Offset, Size or Type missing"));
+          return;
+        }
+      } else {
         if (!symbol) {
           done(new Error("No symbol specified"));
           return;
@@ -164,15 +170,10 @@ module.exports = function (RED) {
           done(new Error("Symbol not found in cache"));
           return;
         }
-        if (ig === undefined) ig = symInfo.indexGroup;
-        if (io === undefined) io = symInfo.indexOffset;
-        if (size === undefined) size = symInfo.size;
-        if (!typeName) typeName = symInfo.typeName;
-      }
-
-      if (ig === undefined || io === undefined || size === undefined || !typeName) {
-        done(new Error("Index Group, Offset, Size or Type missing"));
-        return;
+        ig = symInfo.indexGroup;
+        io = symInfo.indexOffset;
+        size = symInfo.size;
+        typeName = symInfo.typeName;
       }
 
       const valueBuf = encodeValue(typeName, size, msg.payload);


### PR DESCRIPTION
## Summary
- allow ads read node to toggle manual index parameters
- allow ads write node to toggle manual index parameters
- document manual value option in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b995c655748324988fc2c324a7bac3