### PR TITLE
Handle ADS errors and send symbol version as string

### DIFF
--- a/nodes/ads-over-mqtt-sym-version-monitor.js
+++ b/nodes/ads-over-mqtt-sym-version-monitor.js
@@ -77,7 +77,8 @@ module.exports = function (RED) {
 
     node.on("input", () => {
       readSymVersion((current) => {
-        node.send([null, { payload: current }, null]);
+        const secondOutputMsg = { payload: current.toString() };
+        node.send([null, secondOutputMsg, null]);
       });
       node.send([null, null, { payload: !!lastOnline }]);
     });
@@ -96,7 +97,10 @@ module.exports = function (RED) {
         const len = message.readUInt32LE(36);
         const data = message.slice(40, 40 + len);
         if (result !== 0) {
-          sendOutput("sym_version");
+          node.status({ fill: "red", shape: "dot", text: "ADS error " + result });
+          const errorMsg = { payload: "ADS read error: " + result };
+          node.error(errorMsg.payload);
+          node.send([errorMsg, null, null]);
           return;
         }
         if (len >= 4) {


### PR DESCRIPTION
## Summary
- Convert symbol version monitor's callback output to a string before sending
- Add ADS error status and message when non-zero result detected

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baa1e47ee0832482974a8619d4df96