### PR TITLE
feat: emit raw ADS response buffer in sym version monitor

### DIFF
--- a/nodes/ads-over-mqtt-sym-version-monitor.html
+++ b/nodes/ads-over-mqtt-sym-version-monitor.html
@@ -10,7 +10,7 @@
     },
     inputs: 1,
     outputs: 3,
-    outputLabels: ["events", "sym_version", "online status"],
+    outputLabels: ["events", "res buffer", "online status"],
     icon: 'bridge.png',
     label: function() {
       return this.name || 'ads sym monitor';
@@ -52,7 +52,7 @@
   <p>Sending any message to the input triggers a one-off read of the current symbol version and immediately outputs the last known online state. The outputs are:</p>
   <ul>
     <li><strong>Output 1</strong> – <code>"liste aktualisiert"</code> events when the symbol version increases or the target goes from offline to online.</li>
-    <li><strong>Output 2</strong> – current symbol version in <code>msg.payload</code> when requested.</li>
+    <li><strong>Output 2</strong> – raw AMS response buffer in <code>msg.payload</code> when requested.</li>
     <li><strong>Output 3</strong> – boolean online status in <code>msg.payload</code> representing the latest known state.</li>
   </ul>
   <p>Use the button to simulate a boot and restart the monitoring.</p>


### PR DESCRIPTION
## Summary
- emit raw AMS response buffer on second output when triggering sym version monitor
- update editor label and help documentation for buffer output

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baa35eac108324924a357f433e5583