### PR TITLE
Use 1-byte sym_version change detection

### DIFF
--- a/nodes/ads-over-mqtt-sym-version-monitor.html
+++ b/nodes/ads-over-mqtt-sym-version-monitor.html
@@ -57,8 +57,8 @@
   <p>Monitors the ADS symbol table version and the target info topic.</p>
   <p>The node can poll the symbol version cyclically when <i>Zyklische Abfrage aktiv</i> is enabled. Sending any message to the input performs the same action as a polling tick. The outputs are:</p>
   <ul>
-    <li><strong>Output 1</strong> – <code>"liste aktualisiert"</code> events when the symbol version increases or the target goes from offline to online.</li>
-    <li><strong>Output 2</strong> – debug information including the decoded symbol version for every read.</li>
+    <li><strong>Output 1</strong> – <code>"liste aktualisiert"</code> events when the symbol version changes or the target goes from offline to online.</li>
+    <li><strong>Output 2</strong> – debug information with the raw ADS response buffer in <code>msg.payload</code> and the decoded symbol version byte in <code>msg.value</code>.</li>
     <li><strong>Output 3</strong> – boolean online status in <code>msg.payload</code> representing the latest known state.</li>
   </ul>
   <p>Use the button to simulate a boot and restart the monitoring.</p>


### PR DESCRIPTION
## Summary
- monitor sym_version using single-byte change detection
- decode and log raw response buffer with value
- document new debug output format and change-trigger behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68babff32cc083248bed624e0d50d6b1